### PR TITLE
Add the ability to focus/unfocus the current pane.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -29,6 +29,6 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
-  { "keys": ["ctrl+k", "ctrl+f"], "command": "focus_pane", "args": {} },
-  { "keys": ["ctrl+k", "ctrl+shift+f"], "command": "unfocus_pane", "args": {} }
+  { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {} },
+  { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -29,7 +29,7 @@
   { "keys": ["super+k", "super+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["super+k", "super+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
-  { "keys": ["super+k", "super+f"], "command": "focus_pane", "args": {} },
-  { "keys": ["super+k", "super+shift+f"], "command": "unfocus_pane", "args": {} }
+  { "keys": ["super+k", "super+z"], "command": "zoom_pane", "args": {} },
+  { "keys": ["super+k", "super+shift+z"], "command": "unzoom_pane", "args": {} }
 
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -29,6 +29,6 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
-  { "keys": ["ctrl+k", "ctrl+f"], "command": "focus_pane", "args": {} }, 
-  { "keys": ["ctrl+k", "ctrl+shift+f"], "command": "unfocus_pane", "args": {} }  
+  { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {} }, 
+  { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} }  
 ]

--- a/Origami.sublime-commands
+++ b/Origami.sublime-commands
@@ -29,7 +29,7 @@
 	{ "command": "create_pane_with_file", "args": {"direction": "down"}, "caption": "Origami: Create Pane with File Below" },
 	{ "command": "create_pane_with_file", "args": {"direction": "left"}, "caption": "Origami: Create Pane with File on the Left" },
 
-	{ "command": "focus_pane", "args": {}, "caption": "Origami: Focus Current Pane" },
-	{ "command": "unfocus_pane", "args": {}, "caption": "Origami: Unfocus Current Pane" },
+	{ "command": "zoom_pane", "args": {}, "caption": "Origami: Zoom Current Pane" },
+	{ "command": "unzoom_pane", "args": {}, "caption": "Origami: Unzoom Current Pane" },
 
 ]

--- a/origami.py
+++ b/origami.py
@@ -124,7 +124,7 @@ class PaneCommand(sublime_plugin.WindowCommand):
 		self.create_pane(direction)
 		self.carry_file_to_pane(direction)
 
-	def focus_pane(self):
+	def zoom_pane(self):
 		window = self.window
 		rows,cols,cells = self.get_layout()
 		current_cell = cells[window.active_group()]
@@ -132,24 +132,27 @@ class PaneCommand(sublime_plugin.WindowCommand):
 		current_col = current_cell[0]
 		num_cols = len(cols)-1
 
-		current_col_width = 1-(0.025*(num_cols-1));
+		current_col_width = 1 if num_cols==1 else 0.9
+		other_col_width = 0 if num_cols==1 else (1-current_col_width)/(num_cols-1)
+
 		cols = [0.0]
 		for i in range(0,num_cols):
-			cols.append(cols[i] + (current_col_width if i == current_col else .025))
+			cols.append(cols[i] + (current_col_width if i == current_col else other_col_width))
 
 		current_row = current_cell[1]
 		num_rows = len(rows)-1
 
-		current_row_height = 1-(0.025*(num_rows-1));
+		current_row_height = 1 if num_rows==1 else 0.9
+		other_row_height = 0 if num_rows==1 else (1-current_row_height)/(num_rows-1)
 		rows = [0.0]
 		for i in range(0,num_rows):
-			rows.append(rows[i] + (current_row_height if i == current_row else .025))
+			rows.append(rows[i] + (current_row_height if i == current_row else other_row_height))
 
 		layout = {"cols": cols, "rows": rows, "cells": cells}
 		print(layout)
 		window.set_layout(layout)
 
-	def unfocus_pane(self):
+	def unzoom_pane(self):
 		window = self.window
 		rows,cols,cells = self.get_layout()
 		current_cell = cells[window.active_group()]
@@ -278,15 +281,13 @@ class CreatePaneWithFileCommand(PaneCommand):
 	def run(self, direction):
 		self.create_pane_with_file(direction)
 
-class FocusPaneCommand(PaneCommand):
+class ZoomPaneCommand(PaneCommand):
 	def run(self):
-		print("focus")
-		self.focus_pane()
+		self.zoom_pane()
 
-class UnfocusPaneCommand(PaneCommand):
+class UnzoomPaneCommand(PaneCommand):
 	def run(self):
-		print("unfocus")
-		self.unfocus_pane()
+		self.unzoom_pane()
 
 class CreatePaneCommand(PaneCommand):
 	def run(self, direction):


### PR DESCRIPTION
Add the ability to focus/unfocus the current pane. This means making the current pane take up the majority of the current working space and shrinking all other panes down to very minimal size. This allows you to focus working on one pane without destroying the others. I find it very useful on a screen with a smaller resolution
