### PR TITLE
Added a CreatePaneWithClonedFileCommand.

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -358,6 +358,12 @@ class CreatePaneWithFileCommand(PaneCommand):
 		self.carry_file_to_pane(direction)
 
 
+class CreatePaneWithClonedFileCommand(PaneCommand):
+	def run(self, direction):
+		self.create_pane(direction)
+		self.clone_file_to_pane(direction)
+
+
 class ZoomPaneCommand(PaneCommand):
 	def run(self, fraction=None):
 		self.zoom_pane(fraction)


### PR DESCRIPTION
This allows people to split their window horizontally or vertically with a
single key binding. This behavior is found in jEdit: Command+2 splits the window vertically, and Command+3 splits the window horizontally.
