### PR TITLE
Closes issue #71

### DIFF
--- a/Origami.sublime-settings
+++ b/Origami.sublime-settings
@@ -1,5 +1,23 @@
 {
     /**
+     * The "syntax_grouping" key determines if you want
+     * Origami to attempt to group files with the same syntax
+     * into the same pane. The default if "false".
+     *
+     * The "enabled_syntaxes" key holds a list of syntaxes
+     * that qualify for grouping. Each syntax should be entered as
+     * a string. A blank list means all syntaxes qualify. If you are
+     * unsure of the correct syntax name, you can open the Sublime console
+     * and enter the following command:
+     *   sublime.active_window().active_view().settings().get('syntax')
+     * The name of the tmLanguage file is what you want.
+     * Ex// ["json", "python"]
+    */
+    "syntax_grouping": false,
+    "enabled_syntaxes": [],
+
+
+    /**
      * The "saved_layouts" key holds a list of previously
      * saved layout settings. These can be set using the
      * "Origami: Save Current Layout" command, they can be

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,8 @@ You can have Origami automatically zoom the active pane by setting `origami_auto
 
 Origami can also automatically close a pane for you once you've closed the last file in it. Just set `origami_auto_close_empty_panes` to true in your user preferences.
 
+Origami can also automatically move files of the same syntax into the same pane group when opening them. Set `syntax_grouping` to `true` in your user or project settings. If you only want specific syntax types to be automatically grouped, you can selectively enable them using the `enabled_syntaxes` list in your user or project settings. (If you don't know the syntax name to use, you can open the Sublime console with <kbd>CTRL</kbd>+<kbd>~</kbd> and type `sublime.active_window().active_view().settings().get('syntax')`. Copy the name of the _tmLanguage_ file without the path parameters.
+
 Install
 -------
 


### PR DESCRIPTION
> Adds AutoSwitchPane EventListener to auto-group files by syntax

I'm not sure if this is 100% what @fbm-static was looking for, but this seemed like a more practical approach to the underlying issue. When enabled, Origami will attempt to move loaded files of the same syntax into the same group (if available). You can also selectively enable this feature for specific syntax types in your User or Project settings files as well (in case that ever needs to happen). This feature is opt-in (e.g. disabled by default).

Let me know your thoughts. It should work in ST2 & ST3, although admittedly I was having some issues/inconsistencies with how ST2 wanted to deal with groups.