### PR TITLE
Add PullFileFromPaneCommand

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -35,6 +35,10 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
+
+  // You can pull a file from another pane by binding the following command:
+  // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
+
   { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
   { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -35,6 +35,10 @@
   { "keys": ["super+k", "super+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["super+k", "super+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
+
+  // You can pull a file from another pane by binding the following command:
+  // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
+
   { "keys": ["super+k", "super+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
   { "keys": ["super+k", "super+shift+z"], "command": "unzoom_pane", "args": {} },
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -35,6 +35,10 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
   
+
+  // You can pull a file from another pane by binding the following command:
+  // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
+
   { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
   { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
 

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -84,6 +84,16 @@
                                     { "command": "clone_file_to_pane", "args": {"direction": "right"}, "caption": "Right" },
                                     { "command": "clone_file_to_pane", "args": {"direction": "left"}, "caption": "Left" }
                                 ]
+                            },
+                            {
+                                "caption": "Pull from",
+                                "children":
+                                [
+                                    { "command": "pull_file_from_pane", "args": {"direction": "up"}, "caption": "Above" },
+                                    { "command": "pull_file_from_pane", "args": {"direction": "down"}, "caption": "Below" },
+                                    { "command": "pull_file_from_pane", "args": {"direction": "right"}, "caption": "Right" },
+                                    { "command": "pull_file_from_pane", "args": {"direction": "left"}, "caption": "Left" }
+                                ]
                             }
                         ]
                     },

--- a/Origami.sublime-commands
+++ b/Origami.sublime-commands
@@ -24,6 +24,11 @@
 	{ "command": "create_pane", "args": {"direction": "down", "give_focus": true}, "caption": "Origami: Create and Focus Pane Below" },
 	{ "command": "create_pane", "args": {"direction": "left", "give_focus": true}, "caption": "Origami: Create and Focus Pane on the Left" },
 
+	{ "command": "pull_file_from_pane", "args": {"direction": "up"}, "caption": "Origami: Pull File from Pane Above" },
+	{ "command": "pull_file_from_pane", "args": {"direction": "right"}, "caption": "Origami: Pull File from Pane on the Right" },
+	{ "command": "pull_file_from_pane", "args": {"direction": "down"}, "caption": "Origami: Pull File from Pane Below" },
+	{ "command": "pull_file_from_pane", "args": {"direction": "left"}, "caption": "Origami: Pull File from Pane on the Left" },
+
 	{ "command": "destroy_pane", "args": {"direction": "up"}, "caption": "Origami: Destroy Pane Above" },
 	{ "command": "destroy_pane", "args": {"direction": "right"}, "caption": "Origami: Destroy Pane on the Right" },
 	{ "command": "destroy_pane", "args": {"direction": "down"}, "caption": "Origami: Destroy Pane Below" },

--- a/origami.py
+++ b/origami.py
@@ -483,6 +483,19 @@ class PaneCommand(sublime_plugin.WindowCommand):
 			layout = {"cols": cols, "rows": rows, "cells": cells}
 			fixed_set_layout(window, layout)
 
+	def pull_file_from_pane(self, direction):
+		adjacent_cell = self.adjacent_cell(direction)
+
+		if adjacent_cell:
+			cells = self.get_cells()
+			group_index = cells.index(adjacent_cell)
+
+			view = self.window.active_view_in_group(group_index)
+
+			if view:
+				active_group_index = self.window.active_group()
+				self.window.set_view_index(view, active_group_index, 0)
+
 
 class TravelToPaneCommand(PaneCommand):
 	def run(self, direction):
@@ -509,6 +522,11 @@ class CreatePaneWithClonedFileCommand(PaneCommand):
 	def run(self, direction):
 		self.create_pane(direction)
 		self.clone_file_to_pane(direction)
+
+
+class PullFileFromPaneCommand(PaneCommand):
+	def run(self, direction):
+		self.pull_file_from_pane(direction)
 
 
 class ZoomPaneCommand(PaneCommand):


### PR DESCRIPTION
This allows to pull files from another panes, nothing fancy but useful in some cases. I commented the keybindings because I use `super+k, super+ctrl+<direction>` on my Mac but `ctrl` is already taken on Linux and Windows and I couldn’t think of any better combination.