### PR TITLE
Create a new pane if none exists

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -114,6 +114,8 @@ class PaneCommand(sublime_plugin.WindowCommand):
 			cells = self.get_cells()
 			new_group_index = cells.index(adjacent_cell)
 			self.window.focus_group(new_group_index)
+		else:
+			self.create_pane(direction, True)
 
 	def carry_file_to_pane(self, direction):
 		view = self.window.active_view()


### PR DESCRIPTION
Hi,

Just installed this amazing plugin and I'm really digging it. The only thing that annoys me is that in order to move a file I'm working on to a separate pane I need to create a pane first and then move the file.

With this small change whenever you are switching to a non-existing pane it will create one. Also moving/cloning a file to a non-existing pane will create one.