### PR TITLE
Fix CloneFileToPaneCommand error

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -521,7 +521,7 @@ class CarryFileToPaneCommand(PaneCommand, WithSettings):
 		self.carry_file_to_pane(direction, create_new_if_necessary)
 
 
-class CloneFileToPaneCommand(PaneCommand):
+class CloneFileToPaneCommand(PaneCommand, WithSettings):
 	def run(self, direction, create_new_if_necessary=None):
 		if create_new_if_necessary is None:
 			create_new_if_necessary = self.settings().get('create_new_pane_if_necessary')


### PR DESCRIPTION
```
  File "origami in /Users/m.arizuka/Library/Application Support/Sublime Text 3/Installed Packages/Origami.sublime-package", line 527, in run
AttributeError: 'CloneFileToPaneCommand' object has no attribute 'settings'
```

This fixes above error.

