### PR TITLE
Load package's user settings instead of global preferences

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -605,7 +605,7 @@ class SaveLayoutCommand(PaneCommand, WithSettings):
 
 			if sublime.ok_cancel_dialog(dialog_str, dialog_btn):
 				def get_index(seq, attr, value):
-				    return next(i for (i, d) in enumerate(seq) if d[attr] == value)
+					return next(i for (i, d) in enumerate(seq) if d[attr] == value)
 
 				layout = saved_layouts[get_index(saved_layouts, 'nickname', nickname)]
 				layout['rows'] = layout_data[0]
@@ -738,7 +738,7 @@ class NewWindowWithCurrentLayoutCommand(PaneCommand):
 
 class AutoCloseEmptyPanes(sublime_plugin.EventListener):
 	def on_close(self, view):
-    	auto_close = view.settings().get("origami_auto_close_empty_panes", False)
+		auto_close = view.settings().get("origami_auto_close_empty_panes", False)
 		auto_close = sublime.load_settings('Origami.sublime-settings').get('origami_auto_close_empty_panes', False)
 		if not auto_close:
 			return
@@ -780,7 +780,7 @@ class AutoZoomOnFocus(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		if self.running:
 			return
-    	fraction = view.settings().get("origami_auto_zoom_on_focus", False)
+		fraction = view.settings().get("origami_auto_zoom_on_focus", False)
 		fraction = sublime.load_settings('Origami.sublime-settings').get("origami_auto_zoom_on_focus", False)
 		if not fraction:
 			return

--- a/origami.py
+++ b/origami.py
@@ -738,7 +738,8 @@ class NewWindowWithCurrentLayoutCommand(PaneCommand):
 
 class AutoCloseEmptyPanes(sublime_plugin.EventListener):
 	def on_close(self, view):
-		auto_close = view.settings().get("origami_auto_close_empty_panes", False)
+    # auto_close = view.settings().get("origami_auto_close_empty_panes", False)
+		auto_close = sublime.load_settings('Origami.sublime-settings').get('origami_auto_close_empty_panes', False)
 		if not auto_close:
 			return
 		window = sublime.active_window()
@@ -779,7 +780,8 @@ class AutoZoomOnFocus(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		if self.running:
 			return
-		fraction = view.settings().get("origami_auto_zoom_on_focus", False)
+    # fraction = view.settings().get("origami_auto_zoom_on_focus", False)
+		fraction = sublime.load_settings('Origami.sublime-settings').get("origami_auto_zoom_on_focus", False)
 		if not fraction:
 			return
 		if view.settings().get("is_widget"):

--- a/origami.py
+++ b/origami.py
@@ -738,7 +738,7 @@ class NewWindowWithCurrentLayoutCommand(PaneCommand):
 
 class AutoCloseEmptyPanes(sublime_plugin.EventListener):
 	def on_close(self, view):
-    # auto_close = view.settings().get("origami_auto_close_empty_panes", False)
+    	auto_close = view.settings().get("origami_auto_close_empty_panes", False)
 		auto_close = sublime.load_settings('Origami.sublime-settings').get('origami_auto_close_empty_panes', False)
 		if not auto_close:
 			return
@@ -780,7 +780,7 @@ class AutoZoomOnFocus(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		if self.running:
 			return
-    # fraction = view.settings().get("origami_auto_zoom_on_focus", False)
+    	fraction = view.settings().get("origami_auto_zoom_on_focus", False)
 		fraction = sublime.load_settings('Origami.sublime-settings').get("origami_auto_zoom_on_focus", False)
 		if not fraction:
 			return


### PR DESCRIPTION
This pull request loads the Origami.sublime-settings file instead of grabbing the Preferences object from view.settings(). This will specifically grab the auto-close and auto-zoom preferences from the lower-scoped package user settings rather than the Preferences.