### PR TITLE
"Focus file on pane" and "Focus or clone file on pane" commands added

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Other contributors:
 
 * David Baumgold (singingwolfboy), <david@davidbaumgold.com>
 * Ryan Morrissey (23maverick23), <contactme@ryancmorrissey.com>
+* Carlos L. Perez (clperez), <me@qwantalabs.com>

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -79,6 +79,26 @@
                             { "command": "pull_file_from_pane", "args": {"direction": "right"}, "caption": "Right" },
                             { "command": "pull_file_from_pane", "args": {"direction": "left"}, "caption": "Left" }
                         ]
+                    },
+                    {
+                        "caption": "Focus on",
+                        "children":
+                        [
+                            { "command": "focus_file_on_pane", "args": {"direction": "up"}, "caption": "Above" },
+                            { "command": "focus_file_on_pane", "args": {"direction": "down"}, "caption": "Below" },
+                            { "command": "focus_file_on_pane", "args": {"direction": "right"}, "caption": "Right" },
+                            { "command": "focus_file_on_pane", "args": {"direction": "left"}, "caption": "Left" }
+                        ]
+                    },
+                    {
+                        "caption": "Focus or Clone to",
+                        "children":
+                        [
+                            { "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"}, "caption": "Above" },
+                            { "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"}, "caption": "Below" },
+                            { "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"}, "caption": "Right" },
+                            { "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"}, "caption": "Left" }
+                        ]
                     }
                 ]
             },

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -16,6 +16,20 @@
   // You can also create the pane automatically with the following command (insert empty parameters):
   // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
 
+  { "keys": ["ctrl+k", "ctrl+alt+shift+up"], "command": "focus_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+right"], "command": "focus_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+down"], "command": "focus_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+left"], "command": "focus_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+up"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+right"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+down"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+left"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+  
   { "keys": ["ctrl+k", "ctrl+up"], "command": "create_pane", "args": {"direction": "up"} },
   { "keys": ["ctrl+k", "ctrl+right"], "command": "create_pane", "args": {"direction": "right"} },
   { "keys": ["ctrl+k", "ctrl+down"], "command": "create_pane", "args": {"direction": "down"} },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -16,6 +16,20 @@
   // You can also create the pane automatically with the following command (insert empty parameters):
   // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
 
+  { "keys": ["super+k", "super+alt+shift+up"], "command": "focus_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["super+k", "super+alt+shift+right"], "command": "focus_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["super+k", "super+alt+shift+down"], "command": "focus_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["super+k", "super+alt+shift+left"], "command": "focus_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+
+  { "keys": ["super+k", "super+i" , "super+alt+shift+up"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["super+k", "super+i" , "super+alt+shift+right"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["super+k", "super+i" , "super+alt+shift+down"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["super+k", "super+i" , "super+alt+shift+left"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+
   { "keys": ["super+k", "super+up"], "command": "create_pane", "args": {"direction": "up"} },
   { "keys": ["super+k", "super+right"], "command": "create_pane", "args": {"direction": "right"} },
   { "keys": ["super+k", "super+down"], "command": "create_pane", "args": {"direction": "down"} },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -16,6 +16,20 @@
   // You can also create the pane automatically with the following command (insert empty parameters):
   // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
 
+  { "keys": ["ctrl+k", "ctrl+alt+shift+up"], "command": "focus_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+right"], "command": "focus_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+down"], "command": "focus_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["ctrl+k", "ctrl+alt+shift+left"], "command": "focus_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+up"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+right"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+down"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"} },
+  { "keys": ["ctrl+k", "ctrl+i" , "ctrl+alt+shift+left"], "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"} },
+  // You can also create the pane automatically with the following command (insert empty parameters):
+  // { "keys": [], "command": "create_pane_with_cloned_file", "args": {"direction": ""} }
+  
   { "keys": ["ctrl+k", "ctrl+up"], "command": "create_pane", "args": {"direction": "up"} },
   { "keys": ["ctrl+k", "ctrl+right"], "command": "create_pane", "args": {"direction": "right"} },
   { "keys": ["ctrl+k", "ctrl+down"], "command": "create_pane", "args": {"direction": "down"} },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -94,7 +94,27 @@
                                     { "command": "pull_file_from_pane", "args": {"direction": "right"}, "caption": "Right" },
                                     { "command": "pull_file_from_pane", "args": {"direction": "left"}, "caption": "Left" }
                                 ]
-                            }
+                            },
+                            {
+                                "caption": "Focus on",
+                                "children":
+                                [
+                                    { "command": "focus_file_on_pane", "args": {"direction": "up"}, "caption": "Above" },
+                                    { "command": "focus_file_on_pane", "args": {"direction": "down"}, "caption": "Below" },
+                                    { "command": "focus_file_on_pane", "args": {"direction": "right"}, "caption": "Right" },
+                                    { "command": "focus_file_on_pane", "args": {"direction": "left"}, "caption": "Left" }
+                                ]
+                            },
+                            {
+                                "caption": "Focus/clone to",
+                                "children":
+                                [
+                                    { "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"}, "caption": "Above" },
+                                    { "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"}, "caption": "Below" },
+                                    { "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"}, "caption": "Right" },
+                                    { "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"}, "caption": "Left" }
+                                ]
+                            },
                         ]
                     },
                     {

--- a/Origami.sublime-commands
+++ b/Origami.sublime-commands
@@ -19,10 +19,10 @@
 	{ "command": "focus_file_on_pane", "args": {"direction": "down"}, "caption": "Origami: Focus File on the Pane Below" },
 	{ "command": "focus_file_on_pane", "args": {"direction": "left"}, "caption": "Origami: Focus File on the Pane on the Left" },
 
-	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"}, "caption": "Origami: or Clone File on the Pane Above" },
-	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"}, "caption": "Origami: or Clone File on the Pane on the Right" },
-	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"}, "caption": "Origami: or Clone File on the Pane Below" },
-	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"}, "caption": "Origami: or Clone File on the Pane on the Left" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"}, "caption": "Origami: Focus or Clone File on the Pane Above" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"}, "caption": "Origami: Focus or Clone File on the Pane on the Right" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"}, "caption": "Origami: Focus or Clone File on the Pane Below" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"}, "caption": "Origami: Focus or Clone File on the Pane on the Left" },
 
 	{ "command": "create_pane", "args": {"direction": "up"}, "caption": "Origami: Create Pane Above" },
 	{ "command": "create_pane", "args": {"direction": "right"}, "caption": "Origami: Create Pane on the Right" },

--- a/Origami.sublime-commands
+++ b/Origami.sublime-commands
@@ -11,8 +11,18 @@
 
 	{ "command": "clone_file_to_pane", "args": {"direction": "up"}, "caption": "Origami: Clone File to Pane Above" },
 	{ "command": "clone_file_to_pane", "args": {"direction": "right"}, "caption": "Origami: Clone File to Pane on the Right" },
-	{ "command": "clone_file_to_pane", "args": {"direction": "down"}, "caption": "Origami: Clone File to Pane Below" },
+	{ "command": "clone_file_to_pane", "args": {"direction": "down"}, "cakption": "Origami: Clone File to Pane Below" },
 	{ "command": "clone_file_to_pane", "args": {"direction": "left"}, "caption": "Origami: Clone File to Pane on the Left" },
+
+	{ "command": "focus_file_on_pane", "args": {"direction": "up"}, "caption": "Origami: Focus File on the Pane Above" },
+	{ "command": "focus_file_on_pane", "args": {"direction": "right"}, "caption": "Origami: Focus File on the Pane on the Right" },
+	{ "command": "focus_file_on_pane", "args": {"direction": "down"}, "caption": "Origami: Focus File on the Pane Below" },
+	{ "command": "focus_file_on_pane", "args": {"direction": "left"}, "caption": "Origami: Focus File on the Pane on the Left" },
+
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "up"}, "caption": "Origami: or Clone File on the Pane Above" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "right"}, "caption": "Origami: or Clone File on the Pane on the Right" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "down"}, "caption": "Origami: or Clone File on the Pane Below" },
+	{ "command": "focus_or_clone_file_on_pane", "args": {"direction": "left"}, "caption": "Origami: or Clone File on the Pane on the Left" },
 
 	{ "command": "create_pane", "args": {"direction": "up"}, "caption": "Origami: Create Pane Above" },
 	{ "command": "create_pane", "args": {"direction": "right"}, "caption": "Origami: Create Pane on the Right" },

--- a/origami.py
+++ b/origami.py
@@ -131,6 +131,14 @@ class PaneCommand(sublime_plugin.WindowCommand):
 				
 		return buffer_exists, target_view
 
+	def clone_viewport (self, view, new_view):
+		new_sel = new_view.sel()
+		new_sel.clear()
+		for s in view.sel():
+			new_sel.add(s)
+
+		sublime.set_timeout(lambda : new_view.set_viewport_position(view.viewport_position(), False), 0)
+
 	def travel_to_pane(self, direction, create_new_if_necessary=False):
 		adjacent_cell = self.adjacent_cell(direction)
 		if adjacent_cell:
@@ -145,6 +153,7 @@ class PaneCommand(sublime_plugin.WindowCommand):
 		if view == None:
 			# If we're in an empty group, there's no active view
 			return
+
 		window = self.window
 		self.travel_to_pane(direction, create_new_if_necessary)
 		window.set_view_index(view, window.active_group(), 0)
@@ -165,12 +174,7 @@ class PaneCommand(sublime_plugin.WindowCommand):
 		window.set_view_index(new_view, group, original_index)
 
 		# Fix the new view's selection and viewport
-		new_sel = new_view.sel()
-		new_sel.clear()
-		for s in view.sel():
-			new_sel.add(s)
-		sublime.set_timeout(lambda : new_view.set_viewport_position(view.viewport_position(), False), 0)
-
+		self.clone_viewport (view, new_view)
 		self.carry_file_to_pane(direction, create_new_if_necessary)
 
 	def focus_file_on_pane(self, direction, create_new_if_necessary=False):
@@ -188,6 +192,7 @@ class PaneCommand(sublime_plugin.WindowCommand):
 		buffer_exists, target_view = self.is_view_in_group(view, target_group)
 		
 		if buffer_exists:
+			self.clone_viewport (view, target_view)
 			window.focus_view(target_view)
 		else:
 		 	window.focus_group(source_group)


### PR DESCRIPTION
Hi:

I added this commands because I usually work with two panes, and I configure my navigation commands to show the results on the inactive pane, (in a way that I alternate panes frequently). I make extensive use of "chain of command" and I missed a command to open a file "if not already opened". 

Take a look if you can, and let me know if you thing something needs reviewing. 
One of the things I wasn't completely sure about were the key bindings. 
Maybe the new commands shouldn't have default key bindings. 