### PR TITLE
Disable keybindings conflicting with ST built-in features

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -35,14 +35,16 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
 
-
   // You can pull a file from another pane by binding the following command:
   // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
 
-  { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
-  { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
+  // NOTE: The following keybindings are disabled as they conflict with built-in features.
+  // You can copy those to your user keybindings and change to your choosen combination
+  // or just enable if you don't care about built-in features.
 
-  { "keys": ["ctrl+k", "ctrl+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
-  { "keys": ["ctrl+k", "ctrl+r"], "command": "resize_pane", "args": {"orientation": "rows"} }
+  // { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
+  // { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
 
+  // { "keys": ["ctrl+k", "ctrl+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
+  // { "keys": ["ctrl+k", "ctrl+r"], "command": "resize_pane", "args": {"orientation": "rows"} },
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -35,13 +35,16 @@
   { "keys": ["super+k", "super+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["super+k", "super+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
 
-
   // You can pull a file from another pane by binding the following command:
   // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
 
-  { "keys": ["super+k", "super+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
-  { "keys": ["super+k", "super+shift+z"], "command": "unzoom_pane", "args": {} },
+  // NOTE: The following keybindings are disabled as they conflict with built-in features.
+  // You can copy those to your user keybindings and change to your choosen combination
+  // or just enable if you don't care about built-in features.
 
-  { "keys": ["super+k", "super+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
-  { "keys": ["super+k", "super+r"], "command": "resize_pane", "args": {"orientation": "rows"} }
+  // { "keys": ["super+k", "super+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
+  // { "keys": ["super+k", "super+shift+z"], "command": "unzoom_pane", "args": {} },
+
+  // { "keys": ["super+k", "super+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
+  // { "keys": ["super+k", "super+r"], "command": "resize_pane", "args": {"orientation": "rows"} },
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -35,14 +35,16 @@
   { "keys": ["ctrl+k", "ctrl+alt+down"], "command": "create_pane_with_file", "args": {"direction": "down"} },
   { "keys": ["ctrl+k", "ctrl+alt+left"], "command": "create_pane_with_file", "args": {"direction": "left"} },
 
-
   // You can pull a file from another pane by binding the following command:
   // { "keys": [], "command": "pull_file_from_pane", "args": { "direction": ""} }
 
-  { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
-  { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
+  // NOTE: The following keybindings are disabled as they conflict with built-in features.
+  // You can copy those to your user keybindings and change to your choosen combination
+  // or just enable if you don't care about built-in features.
 
-  { "keys": ["ctrl+k", "ctrl+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
-  { "keys": ["ctrl+k", "ctrl+r"], "command": "resize_pane", "args": {"orientation": "rows"} }
+  // { "keys": ["ctrl+k", "ctrl+z"], "command": "zoom_pane", "args": {"fraction": 0.9} },
+  // { "keys": ["ctrl+k", "ctrl+shift+z"], "command": "unzoom_pane", "args": {} },
 
+  // { "keys": ["ctrl+k", "ctrl+c"], "command": "resize_pane", "args": {"orientation": "cols"} },
+  // { "keys": ["ctrl+k", "ctrl+r"], "command": "resize_pane", "args": {"orientation": "rows"} }
 ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Origami
 =======
+
 Origami is a new way of thinking about panes in Sublime Text: you tell Sublime Text where you want a new pane, and it makes one for you. It works seamlessly alongside the built-in layout commands.
 
 Ordinarily one uses the commands under View>Layout, or if one is quite intrepid a custom keyboard shortcut can be made to give a specific layout, but both of these solutions were unsatisfactory to me. Perhaps they were to you too! That's what this plugin is for.
@@ -8,6 +9,9 @@ Try it out! I think you'll like it.
 
 Keyboard shortcuts
 ------------------
+
+> **NOTE**: Windows and Linux use `ctrl` instead of `command`.
+
 Origami is driven by keyboard shortcuts. By default, these keyboard shortcuts are all two-stage, and are hidden behind `command+k`. First press `command+k`, then press the arrow keys with modifiers:
 
 | First       | Then                    | Action                                    |
@@ -19,6 +23,9 @@ Origami is driven by keyboard shortcuts. By default, these keyboard shortcuts ar
 | `command+k` | `command+shift`+▲►▼◄  | destroy an adjacent pane                  |
 
 These keyboard shortcuts are designed to make it really easy to modify the layout of your editor.
+
+> **NOTE**: The following keyboard shortcuts for zooming and editing pane sizes are not enabled by default due to a conflict with built-in ST features. Open the `Preferences: Origami Key Bindings` from the Command Palette to enable or edit them, or just use the Command Palette to trigger those commands.
+
 
 Additionally, Origami allows one to zoom the current pane, making it take up a large portion of the window:
 
@@ -41,12 +48,9 @@ In the keybindings you can change a `mode` which specifies which separation line
 * `BEFORE` means top (or left) separator
 * `AFTER` means bottom (or right) separator
 
-> **NOTE**: Windows and Linux use `ctrl` instead of `command`.
-
-> **NOTE 2**: The keyboard shortcuts for zooming and editing pane sizes are not enabled by default due to a conflict with built-in ST features. Open the `Preferences: Origami Key Bindings` from the Command Palette to enable or edit them.
-
 Automation
 ----------
+
 You can have Origami automatically zoom the active pane by setting `auto_zoom_on_focus` in your Origami user preferences. Set it to `true` for the default zoom, or set it to a user-definable fraction of the screen, such as `0.75`.
 
 Origami can also automatically close a pane for you once you've closed the last file in it. Just set `auto_close_empty_panes` to true in the Origami preferences.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Origami
-======
+=======
 Origami is a new way of thinking about panes in Sublime Text: you tell Sublime Text where you want a new pane, and it makes one for you. It works seamlessly alongside the built-in layout commands.
 
 Ordinarily one uses the commands under View>Layout, or if one is quite intrepid a custom keyboard shortcut can be made to give a specific layout, but both of these solutions were unsatisfactory to me. Perhaps they were to you too! That's what this plugin is for.
@@ -10,22 +10,29 @@ Keyboard shortcuts
 ------------------
 Origami is driven by keyboard shortcuts. By default, these keyboard shortcuts are all two-stage, and are hidden behind `command+k`. First press `command+k`, then press the arrow keys with modifiers:
 
-* no modifiers: travel to an adjacent pane
-* `shift`: carry the current file to the destination
-* `alt` (`option`): clone the current file to the destination
-* `command`: create an adjacent pane
-* `command+shift`: destroy an adjacent pane
+| First       | Then                    | Action                                    |
+| ----------- | ----------------------- | ----------------------------------------- |
+| `command+k` | ▲►▼◄                  | travel to an adjacent pane                |
+| `command+k` | `shift`+▲►▼◄          | carry the current file to the destination |
+| `command+k` | `alt` (`option`)+▲►▼◄ | clone the current file to the destination |
+| `command+k` | `command`+▲►▼◄        | create an adjacent pane                   |
+| `command+k` | `command+shift`+▲►▼◄  | destroy an adjacent pane                  |
 
 These keyboard shortcuts are designed to make it really easy to modify the layout of your editor.
 
-Additionally, Origami allows one to zoom the current pane, making it take up a large portion of the window. As above, first press `command+k`, then press:
+Additionally, Origami allows one to zoom the current pane, making it take up a large portion of the window:
 
-* `command+z`: Zoom the current pane so it takes up 90% of the screen (the fraction is changeable in the keybindings)
-* `shift+command+z`: Unzoom: equally space all panes
+| First       | Then              | Action                           |
+| ----------- | ----------------- | -------------------------------- |
+| `command+k` | `command+z`       | Zoom the current pane so it takes up 90% of the screen (the fraction is changeable in the keybindings) |
+| `command+k` | `shift+command+z` | Un-zoom: equally space all panes |
 
-It is also possible to edit the pane sizes. After `command+k` press:
-* `command+r`: Adjust the top and bottom separator
-* `command+c`: Adjust the left and right separator
+It is also possible to edit the pane sizes:
+
+| First       | Then        | Action                              |
+| ----------- | ------------| ----------------------------------- |
+| `command+k` | `command+r` | Adjust the top and bottom separator |
+| `command+k` | `command+c` | Adjust the left and right separator |
 
 In the keybindings you can change a `mode` which specifies which separation lines you want to edit.
 * `ALL` means all horizontal (or vertical) separators
@@ -34,7 +41,9 @@ In the keybindings you can change a `mode` which specifies which separation line
 * `BEFORE` means top (or left) separator
 * `AFTER` means bottom (or right) separator
 
-(Note: Windows and Linux use `ctrl` instead of `command`.)
+> **NOTE**: Windows and Linux use `ctrl` instead of `command`.
+
+> **NOTE 2**: The keyboard shortcuts for zooming and editing pane sizes are not enabled by default due to a conflict with built-in ST features. Open the `Preferences: Origami Key Bindings` from the Command Palette to enable or edit them.
 
 Automation
 ----------
@@ -47,7 +56,7 @@ Installation
 
 #### Using package control
 
-1. Open up the command palette: <kbd>ctrl+shift+p</kbd>
+1. Open up the command palette: <kbd>ctrl+shift+p</kbd> (Linux, Windows) / <kbd>cmd+shift+p</kbd> (macOS)
 2. Search for `Package Control: Install Package`
 3. Search for `Origami`
 4. Hit <kbd>enter</kbd> :wink:

--- a/messages.json
+++ b/messages.json
@@ -1,4 +1,4 @@
 {
-  "install": "messages/install.txt",
-  "2018.11.21.0": "messages/2018.11.21.0.txt"
+  "2.1.0": "messages/2.1.0.txt",
+  "install": "messages/install.txt"
 }

--- a/messages/2.1.0.txt
+++ b/messages/2.1.0.txt
@@ -1,0 +1,6 @@
+**BREAKING**:
+ - The default keybindings for zooming and changing pane sizes are now disabled due to a conflict with built-in ST features.
+
+   You can re-enable them by opening the `Preferences: Origami Key Bindings` from the Command Palette and copying
+   disabled keybindings to your user keybindings. Consider changing the key combination if you care about having
+   built-in features.

--- a/messages/2018.11.21.0.txt
+++ b/messages/2018.11.21.0.txt
@@ -1,8 +1,0 @@
-* Added release notes (these!) and an install message.
-
-* All settings can now be set in Origami.sublime-settings.
-  If you are still using the User settings, Origami will still read those too.
-
-* If you have auto_close_empty_panes enabled, Origami will no longer close panes
-  when transient views are closed. This fixes a bug where you couldn't use the
-  command palette to open a file in a new pane you just created.


### PR DESCRIPTION
- Disable super+k, super+z keybinding that conflicts with "Revert hunk".
- Disable super+k, super+c that conflicts with "Scroll to selection"
- Disable also keybindings relevant to aforementioned ones as it only
   makes sense to have them both enabled or disabled.
- Update readme with some cleaner shortcuts documentation