### PR TITLE
"create adjacent and carry" doesn't carry

### DIFF
--- a/origami.py
+++ b/origami.py
@@ -547,7 +547,7 @@ class CloneFileToPaneCommand(PaneCommand, WithSettings):
 class CreatePaneWithFileCommand(PaneCommand):
 	def run(self, direction):
 		self.create_pane(direction)
-		self.carry_file_to_pane(direction)
+		self.pull_file_from_pane(opposite_direction(direction))
 
 
 class CreatePaneWithClonedFileCommand(PaneCommand):


### PR DESCRIPTION
Resolves https://github.com/SublimeText/Origami/issues/161

When the new pane is created, the cursor ends up there as well. This is why the carry command does not work. I'm not sure when this feature broke or if it behaves differently in ST4 than it did in ST3.

Since the newly created pane becomes active, the file can be pulled from the opposite direction instead.

It can be tested without a code change by adding this keybind:

```json
  {
    "keys": ["ctrl+space", "ctrl+u"],
    "command": "chain",
    "args": {
      "commands": [
        {"command": "create_pane", "args": {"direction": "up"}},
        {"command": "pull_file_from_pane", "args": {"direction": "down"}}
      ]
    }
  },
```

I also tested it locally by uninstalling the package, using my own branch and then using the original keybind to `create_pane_with_file`.