### PR TITLE
Allow marking certain layouts as favourite

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -92,7 +92,8 @@
                         "children":
                         [
                             { "command": "new_window_from_saved_layout", "caption": "From Saved Layout" },
-                            { "command": "new_window_with_current_layout", "caption": "With Current Layout" }
+                            { "command": "new_window_with_current_layout", "caption": "With Current Layout" },
+                            { "command": "new_window_with_favourite_layout", "caption": "With Favourite Layout" }
                         ]
                     }
                 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -106,7 +106,8 @@
                                 "children":
                                 [
                                     { "command": "new_window_from_saved_layout", "caption": "From Saved Layout" },
-                                    { "command": "new_window_with_current_layout", "caption": "With Current Layout" }
+                                    { "command": "new_window_with_current_layout", "caption": "With Current Layout" },
+                                    { "command": "new_window_with_favourite_layout", "caption": "With Favourite Layout" }
                                 ]
                             }
                         ]

--- a/Origami.sublime-commands
+++ b/Origami.sublime-commands
@@ -45,6 +45,7 @@
 	{ "command": "remove_layout", "caption": "Origami: Remove Saved Layout" },
 	{ "command": "new_window_from_saved_layout", "caption": "Origami: New Window from Saved Layout" },
 	{ "command": "new_window_with_current_layout", "caption": "Origami: New Window with Current Layout" },
+	{ "command": "new_window_with_favourite_layout", "caption": "Origami: New Window with Favourite Layout" },
 
 	{ "command": "toggle_zoom_pane", "args": {"fraction": 0.9}, "caption": "Origami: Zoom/Unzoom Current Pane (Toggle Zoom)" },
 	{ "command": "zoom_pane", "args": {"fraction": 0.9}, "caption": "Origami: Zoom Current Pane" },

--- a/origami.py
+++ b/origami.py
@@ -373,7 +373,7 @@ class PaneCommand(sublime_plugin.WindowCommand):
         window.set_layout(layout)
 
     def toggle_zoom(self, fraction):
-        rows, cols, cells = self.get_layout()
+        rows, cols, _ = self.get_layout()
         equal_spacing = True
 
         num_cols = len(cols) - 1
@@ -749,6 +749,33 @@ class NewWindowWithCurrentLayoutCommand(PaneCommand):
         self.window.run_command("new_window")
         new_window = sublime.active_window()
         new_window.set_layout(layout)
+
+class NewWindowWithFavouriteLayoutCommand(PaneCommand, WithSettings):
+    """Opens a new window using the favourite layout settings."""
+
+    def __init__(self, window):
+        self.window = window
+        super(NewWindowWithFavouriteLayoutCommand, self).__init__(window)
+
+    def run(self):
+        if not self.settings().has('saved_layouts'):
+            return
+
+        saved_layouts = self.settings().get('saved_layouts')
+        favourite_layout = next(
+            (layout for layout in saved_layouts if layout['favourite']), None)
+
+        if favourite_layout:
+            layout = {
+                'cells': favourite_layout['cells'],
+                'cols': favourite_layout['cols'],
+                'rows': favourite_layout['rows']
+            }  # type: sublime.Layout
+
+            self.window.run_command("new_window")
+            new_window = sublime.active_window()
+            if new_window.is_valid():
+                new_window.set_layout(layout)
 
 
 class AutoCloseEmptyPanes(sublime_plugin.EventListener, WithSettings):


### PR DESCRIPTION
This commit allows the user to mark certain layouts as favourite for use with `new_window_with_favourite_layout` command, which, much like `new_window_with_current_layout`, opens a new window; the difference is that said marked layout is used as a base instead of the current one.

If there are multiple layouts marked as favourite, only the first (per natural ordering in `saved_layouts`) is chosen.

Why this PR? Most of the time I want to open a new window with the same layout as always. Yet, all I have is that single one - using `new_window_from_saved_layout` for that feels counterproductive. Furthermore, I can't use neither it nor `new_window_with_current_layout` if I'm doing so from e.g. command line when no other windows exist. This is a partial remedy; I'd like to follow it up with a PR introducing a setting that would make Sublime automatically open windows using a certain layout. I haven't thought about the specifics yet - one idea is to use the marker introduced in this PR.